### PR TITLE
Support for mice with registered symbol in name

### DIFF
--- a/naturalscrolling/xinputwarper.py
+++ b/naturalscrolling/xinputwarper.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ### BEGIN LICENSE
 # Copyright (C) 2011 Guillaume Hain <zedtux@zedroot.org>
 #
@@ -27,7 +28,7 @@ class XinputWarper(object):
             cls._instance = super(XinputWarper, cls).__new__(cls, *args,
                                                                  **kwargs)
             cls._instance.__xinput_list_pattern = re.compile(
-                r'\s+([A-z0-9\s\-\(\)\/\.\:\']+)\s+id=(\d+)\s+\[slave\s+pointer.*\]')
+                r'\s+([A-z0-9\s\-\(\)\/\.\:\'®]+)\s+id=(\d+)\s+\[slave\s+pointer.*\]')
             cls._instance.__xinput_list = None
         return cls._instance
 


### PR DESCRIPTION
I made a quick tweak to xinputwarper.py which will allow mice with the registered symbol to appear in the Natural Scrolling menu. Specifically this was to allow my Microsoft mice to work with the application, it appears in xinput as "Microsoft Microsoft® 2.4GHz Transceiver v6.0".
